### PR TITLE
Fix favicon placement

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -2,6 +2,7 @@
     <meta content='text/html; charset=utf-8' http-equiv='Content-Type'>
     <meta http-equiv='X-UA-Compatible' content='IE=edge'>
     <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0'>
+    <link rel="shortcut icon" type="image/jpg" href="{{ '/images/favicon.jpg' | absolute_url }}">
 
     {% if page.excerpt %}
     <meta name="description" content="{{ page.excerpt| strip_html }}" />

--- a/index.html
+++ b/index.html
@@ -1,7 +1,6 @@
 ---
 layout: default
 ---
-<head><link rel="shortcut icon" type="image/jpg" href="{{ "/images/favicon.jpg" | absolute_url }}"></head>
 <div class="posts">
   {% for post in site.posts %}
     <article class="post">


### PR DESCRIPTION
## Summary
- place favicon link in meta head include
- remove stray `<head>` tag from index.html

## Testing
- `jekyll build -d /tmp/site`

------
https://chatgpt.com/codex/tasks/task_e_683f41a45f34832cb405ff9f310fb044