### PR TITLE
Add Jekyll build workflow

### DIFF
--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -1,0 +1,22 @@
+name: Jekyll Build
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+      - name: Install dependencies
+        run: |
+          echo 'source "https://rubygems.org"' > Gemfile
+          echo 'gem "github-pages", group: :jekyll_plugins' >> Gemfile
+          bundle install
+      - name: Build site
+        run: bundle exec jekyll build


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build the Jekyll site

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68406171c574832c8b9408560adf225a