### PR TITLE
Fix duplicate head tag on homepage

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -2,7 +2,7 @@
     <meta content='text/html; charset=utf-8' http-equiv='Content-Type'>
     <meta http-equiv='X-UA-Compatible' content='IE=edge'>
     <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0'>
-    <link rel="shortcut icon" type="image/jpg" href="{{ '/images/favicon.jpg' | absolute_url }}">
+    <link rel="icon" type="image/x-icon" href="{{ '/favicon.ico' | absolute_url }}">
 
     {% if page.excerpt %}
     <meta name="description" content="{{ page.excerpt| strip_html }}" />


### PR DESCRIPTION
## Summary
- keep the homepage template clean by ensuring it doesn't have a custom head
- reference the favicon in `meta.html`

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_68406170b698832c9540cf3389fd7c81