### PR TITLE
Add Newsletter page with AgentMail subscribe/unsubscribe

### DIFF
--- a/content/newsletter.md
+++ b/content/newsletter.md
@@ -1,0 +1,33 @@
+---
+title: "Newsletter"
+url: "/newsletter/"
+description: "Occasional notes from Mason Prince on systems, AI/programming, and security. Subscribe by email or follow the RSS feeds."
+summary: "Occasional notes on systems, AI/programming, and security. Not a daily blast."
+keywords: ["Mason Prince newsletter", "security newsletter", "AI programming", "systems"]
+hidemeta: true
+showtoc: false
+---
+
+Occasional notes from Mason Prince on systems, AI/programming, and security. This is not a daily blast — just a note when there is something worth sending.
+
+### Subscribe
+
+Email [mason-ceo@agentmail.to](mailto:mason-ceo@agentmail.to?subject=Subscribe) with the subject **Subscribe**.
+
+<p><a class="button" href="mailto:mason-ceo@agentmail.to?subject=Subscribe">Subscribe</a></p>
+
+Prefer feeds? RSS is already at [/index.xml](/index.xml) (the whole site) and [/posts/index.xml](/posts/index.xml) (posts only).
+
+### Unsubscribe
+
+Email [mason-ceo@agentmail.to](mailto:mason-ceo@agentmail.to?subject=Unsubscribe) with the subject **Unsubscribe**.
+
+### Recent writing
+
+A few existing posts in that same range:
+
+- [OSWE Exam Review: I Passed — Here's What You Need to Know]({{< relref "posts/oswe-exam-review-passed.md" >}})
+- [Bridging Offensive Security and AI/ML: Halfway Through WGU's MSCSAIML Program]({{< relref "posts/mscsaiml-halfway-through.md" >}})
+- [The Hidden Attack Surface: Security Risks in Model Context Protocol (MCP)]({{< relref "posts/mcp-security.md" >}})
+
+Your address is used only for this list. It is not sold.

--- a/design/newsletter.md
+++ b/design/newsletter.md
@@ -1,0 +1,20 @@
+# Newsletter page
+
+## Problem
+
+The site has RSS but no public way to join an email list. People should be able to subscribe to occasional notes from Mason Prince, sent from `mason-ceo@agentmail.to`, without a third-party ESP embed or a fake backend.
+
+## Approach
+
+- Add a static PaperMod page at `/newsletter/` (`content/newsletter.md`).
+- Subscribe and unsubscribe are `mailto:` links to `mason-ceo@agentmail.to` with subjects `Subscribe` and `Unsubscribe`.
+- Mention existing RSS (`/index.xml`, `/posts/index.xml`).
+- Link only real posts already in the repo.
+- Add a `Newsletter` item to `menu.main` in `hugo.toml`.
+- Do not change homepage profile branding, do not add API keys, and do not invent a sending domain.
+
+## Out of scope
+
+- Custom sending domain or AgentMail API integration
+- Paid ESPs, subscriber counts, or a form backend
+- Homepage copy or offsec branding changes

--- a/hugo.toml
+++ b/hugo.toml
@@ -148,6 +148,12 @@ url = "/about/"
 weight = 40
 
 [[menu.main]]
+identifier = "newsletter"
+name = "Newsletter"
+url = "/newsletter/"
+weight = 45
+
+[[menu.main]]
 identifier = "search"
 name = "Search"
 url = "/search/"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a static `/newsletter/` page so people can join a list sent from `mason-ceo@agentmail.to` (display name Mason Prince), without a third-party ESP or a fake backend.

## What changed

- New PaperMod page at `content/newsletter.md` (`/newsletter/`)
  - Short pitch: occasional notes on systems, AI/programming, and security — not a daily blast
  - Subscribe: email `mason-ceo@agentmail.to` with subject `Subscribe`, plus a `mailto:` button
  - Unsubscribe: same address, subject `Unsubscribe`
  - Mentions existing RSS at `/index.xml` and `/posts/index.xml`
  - One-line privacy: address used only for this list, not sold
  - Links three real posts already in the repo (OSWE exam review, WGU AI/ML halfway, MCP security)
- `Newsletter` added to `menu.main` in `hugo.toml` (between About and Search)
- Homepage profile branding is unchanged

## Notes

- This **is** the Hugo PaperMod site for masonprince93.com (confirmed via `hugo.toml`, PaperMod theme, existing nav, and content).
- No API keys, no custom sending domain, no subscriber counts, no form backend.

## Verified

Built with Hugo 0.146.0 extended:

- `public/newsletter/index.html` exists
- Subscribe button/link is `mailto:mason-ceo@agentmail.to?subject=Subscribe`
- Unsubscribe link is `mailto:mason-ceo@agentmail.to?subject=Unsubscribe`
- Nav includes Newsletter → `/newsletter/` on the homepage and the newsletter page
- `relref` resolves to the existing post permalinks

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e3c1f3f-6809-46e9-bc84-58e8689da06f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e3c1f3f-6809-46e9-bc84-58e8689da06f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

